### PR TITLE
ci: fixed failing build issue caused by deprecated cask-versions

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,5 @@
 # Taps (data sources)
-tap "homebrew/cask-versions" # Access alternative versions for homebrew casks
+tap "homebrew/homebrew-cask" # Access alternative versions for homebrew casks
 
 # terminal programs
 brew "awscli" unless system "aws", "--version"


### PR DESCRIPTION
# Fixed failing build issue caused by deprecated cask-versions

- Fix failing build issue caused by deprecated cask-versions

## Evidence of the change

Previous builds failing:
<img width="1238" alt="image" src="https://github.com/govuk-one-login/mobile-android-logging/assets/5354593/a031db6b-d998-4c0d-866a-e212a41c9f75">

**See successful builds on this pull request:** ✅ 

<img width="993" alt="image" src="https://github.com/govuk-one-login/mobile-android-logging/assets/5354593/3c5a0388-2138-4360-989b-92f033862002">

## Checklist

### Before creating the pull request

- [x] Commit messages that conform to conventional commit messages.
- [x] Ran the app locally ensuring it builds.
- [x] Tests pass locally.
- [x] Pull request has a clear title with a short description about the feature or update.
- [x] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] ~~Complete all Acceptance Criteria within Jira ticket~~
- [x] Self-review code.
- [ ] ~~Successfully run changes on a testing device.~~
- [ ] ~~Complete automated Testing:~~
  * [ ] ~~Unit Tests.~~
  * [ ] ~~Integration Tests~~
  * [ ] ~~Instrumentation / Emulator Tests~~
- [ ] ~~Review [Accessibility considerations]~~
- [ ] Handle PR comments.

### Before merging the pull request

- [ ] [Sonar cloud report] passes inspections for your PR.
- [ ] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=mobile-android-logging
[Accessibility considerations]: https://developer.android.com/guide/topics/ui/accessibility/testing
