### PR TITLE
ci: skip release if there is no change to deploy

### DIFF
--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -68,12 +68,12 @@ jobs:
           git config user.email github-actions@github.com
           
           current_version=$(cog -v get-version)
-          new_version=$(cog bump --dry-run --auto)
-          
           echo "current_version=$current_version" >> $GITHUB_OUTPUT
-          echo "new_version=$new_version" >> $GITHUB_OUTPUT
           
           cog bump --auto
+          
+          new_version=$(cog -v get-version)
+          echo "new_version=$new_version" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Push version commit / tag generated from cocogitto

--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -1,23 +1,19 @@
 name: Release Mobile Android Logging
 on:
-  pull_request:
-    types:
-      - closed
-    branches:
-      - main
+  push:
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:
   bump_version:
     env:
       JDK_VERSION: 17
-    if: github.event.pull_request.merged == true
     permissions:
       id-token: write
       contents: write
       packages: write
     runs-on: ubuntu-latest
-    #    runs-on: ubuntu-20.04-16core # Larger github runner, with KVM acceleration
+
     steps:
       - name: Run checkout github action
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6


### PR DESCRIPTION
Skip the release if there is no change to deploy as part of the merged to main.
This will reduce the number of failed builds.

**Evidence:**
Successful test build here: https://github.com/govuk-one-login/mobile-android-logging/actions/runs/9179166505
