### PR TITLE
feat: Add functionality to get English plural res

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@
 
 activity = "1.9.0" # https://developer.android.com/jetpack/androidx/releases/activity
 android-build-tools = "34.0.0" # https://developer.android.com/tools/releases/build-tools
-android-gradle = "8.4.1" # https://developer.android.com/studio/releases/gradle-plugin
+android-gradle = "8.0.2" # https://developer.android.com/studio/releases/gradle-plugin
 androidx-lifecycle = "2.8.1" # https://developer.android.com/jetpack/androidx/releases/lifecycle
 androidx-test-core = "1.5.0" # https://developer.android.com/jetpack/androidx/releases/test
 androidx-test-ext-junit = "1.1.5" # https://developer.android.com/jetpack/androidx/releases/test

--- a/modules/api/src/main/java/uk/gov/logging/api/analytics/extensions/ResourcesExtensions.kt
+++ b/modules/api/src/main/java/uk/gov/logging/api/analytics/extensions/ResourcesExtensions.kt
@@ -3,6 +3,7 @@ package uk.gov.logging.api.analytics.extensions
 import android.content.Context
 import android.content.res.Configuration
 import android.content.res.Resources
+import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
 import java.util.Locale
 
@@ -31,4 +32,32 @@ fun Context.getEnString(
     vararg formatArgs: Any
 ): String {
     return resources.getEnString(this, id, formatArgs)
+}
+
+@Suppress("AppBundleLocaleChanges")
+fun Resources.getEnQuantityString(
+    context: Context,
+    @PluralsRes
+    id: Int,
+    quantity: Int,
+    vararg formatArgs: Any
+): String {
+    val enConfig = Configuration(configuration)
+    enConfig.setLocale(Locale("en"))
+    val enResources = context.createConfigurationContext(enConfig).resources
+    return if (formatArgs.isEmpty()) {
+        enResources.getQuantityString(id, quantity)
+    } else {
+        enResources.getQuantityString(id, quantity, *formatArgs)
+    }
+}
+
+@Suppress("AppBundleLocaleChanges")
+fun Context.getEnQuantityString(
+    @PluralsRes
+    id: Int,
+    quantity: Int,
+    vararg formatArgs: Any
+): String {
+    return resources.getEnQuantityString(this, id, quantity, formatArgs)
 }


### PR DESCRIPTION
# _Add functionality to get English plural resource strings_
- Add `getEnQuantityString` to get English versions of quantity string resources regardless of device language, for analytics purposes. This was added to `ResourceExtensions.kt`

Resolves: DCMAW-7001

## Checklist

### Before creating the pull request

- [x] Commit messages that conform to conventional commit messages.
- [ ] ~~Ran the app locally ensuring it builds.~~
- [ ] ~~Tests pass locally.~~
- [x] Pull request has a clear title with a short description about the feature or update.
- [x] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [x] Complete all Acceptance Criteria within Jira ticket.
- [x] Self-review code.
- [x] Successfully run changes on a testing device.
- [] ~~Complete automated Testing:~~
- [ ] ~~Review [Accessibility considerations].~~
- [x] Handle PR comments.

### Before merging the pull request

- [x] [Sonar cloud report] passes inspections for your PR.
- [x] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=mobile-android-logging
[Accessibility considerations]: https://developer.android.com/guide/topics/ui/accessibility/testing
