### PR TITLE
ci: attempt run on newer runner to fix issues

### DIFF
--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -11,7 +11,7 @@ jobs:
       id-token: write
       contents: write
       packages: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Run deployment workflow


### PR DESCRIPTION
Updated to ubuntu-24.04 runner to fix broken release builds: 
https://github.com/govuk-one-login/mobile-android-logging/actions/runs/9893567981