### PR TITLE
feat: remove ktor from project

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,8 +21,6 @@ mockito-android = "5.14.2" # https://github.com/mockito/mockito/releases
 mockito-kotlin = "5.4.0" # https://github.com/mockito/mockito-kotlin/releases
 # DI
 dagger = "2.52" # https://github.com/google/dagger/releases
-# Networking
-ktor = "3.0.1" # https://ktor.io/docs/releases.html#release-details
 
 [libraries]
 # Gradle
@@ -52,8 +50,6 @@ mockito-android = { module = "org.mockito:mockito-android", version.ref = "mocki
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "dagger" }
 hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "dagger" }
 hilt-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "dagger" }
-# Networking
-ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-gradle" }

--- a/modules/logging-api/build.gradle.kts
+++ b/modules/logging-api/build.gradle.kts
@@ -72,7 +72,6 @@ dependencies {
     listOf(
         libs.firebase.analytics,
         libs.hilt.android,
-        libs.ktor.client.core,
         platform(libs.firebase.bom)
     ).forEach {
         implementation(it)

--- a/modules/logging-api/src/main/java/uk/gov/logging/api/analytics/parameters/ApiErrorParameters.kt
+++ b/modules/logging-api/src/main/java/uk/gov/logging/api/analytics/parameters/ApiErrorParameters.kt
@@ -1,7 +1,6 @@
 package uk.gov.logging.api.analytics.parameters
 
 import androidx.annotation.CallSuper
-import io.ktor.http.HttpStatusCode
 import uk.gov.logging.api.analytics.extensions.md5
 import uk.gov.logging.api.analytics.logging.ENDPOINT
 import uk.gov.logging.api.analytics.logging.FORTY_CHAR_LIMIT
@@ -30,7 +29,7 @@ import uk.gov.logging.api.analytics.logging.STATUS
  */
 data class ApiErrorParameters(
     private val endpoint: String,
-    private val status: Int = HttpStatusCode.InternalServerError.value,
+    private val status: Int = DEFAULT_HTTP_STATUS,
     private val overrides: Mapper? = null
 ) : Mapper {
 
@@ -78,5 +77,9 @@ data class ApiErrorParameters(
         bundle.putAll(overrides?.asMap() ?: mapOf())
 
         return bundle
+    }
+
+    companion object {
+        private const val DEFAULT_HTTP_STATUS = 500
     }
 }

--- a/modules/logging-api/src/test/java/uk/gov/logging/api/analytics/parameters/ApiErrorParametersTest.kt
+++ b/modules/logging-api/src/test/java/uk/gov/logging/api/analytics/parameters/ApiErrorParametersTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.logging.api.analytics.parameters
 
-import io.ktor.http.HttpStatusCode
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -19,7 +18,7 @@ class ApiErrorParametersTest {
         try {
             ApiErrorParameters(
                 endpoint = fortyTwoString,
-                status = HttpStatusCode.OK.value
+                status = 200
             )
             fail {
                 "The endpoint should have thrown an exception!"


### PR DESCRIPTION
This is to simplify dependencies. The use of Ktor was purely to access `HttpStatusCodes`, this is nice however the status code was not being used by the analytics event requesting it, merely passing it on. The loss of type safety here I believe is out weighed by the simplification of dependencies.

## Checklist

### Before creating the pull request

- [ ] Commit messages that conform to conventional commit messages.
- [ ] Ran the app locally ensuring it builds.
- [ ] Tests pass locally.
- [ ] Pull request has a clear title with a short description about the feature or update.
- [ ] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] Complete all Acceptance Criteria within Jira ticket.
- [ ] Self-review code.
- [ ] Successfully run changes on a testing device.
- [ ] Complete automated Testing:
  * [ ] Unit Tests.
  * [ ] Integration Tests.
  * [ ] Instrumentation / Emulator Tests.
- [ ] Review [Accessibility considerations].
- [ ] Handle PR comments.

### Before merging the pull request

- [ ] [Sonar cloud report] passes inspections for your PR.
- [ ] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=mobile-android-logging
[Accessibility considerations]: https://developer.android.com/guide/topics/ui/accessibility/testing
