### PR TITLE
feat: Add additional TaxonomyLeve3 params

### DIFF
--- a/modules/logging-api/src/main/java/uk/gov/logging/api/analytics/parameters/data/TaxonomyLevel3.kt
+++ b/modules/logging-api/src/main/java/uk/gov/logging/api/analytics/parameters/data/TaxonomyLevel3.kt
@@ -14,5 +14,7 @@ enum class TaxonomyLevel3(val value: String) {
     SIGN_OUT("sign out"),
     RE_AUTH("re auth"),
     RESUME("resume"),
+    UNLOCK("unlock"),
+    BIOMETRICS("biometrics"),
     UNDEFINED("undefined"),
 }


### PR DESCRIPTION
- add additional TaxonomyLeve3 params for `BioOptInScreen` and `unlock` on `SplashScreen` in one-login app
