### PR TITLE
feat: Add param required for TaxonomyLevel2

### DIFF
--- a/modules/logging-api/src/main/java/uk/gov/logging/api/analytics/parameters/data/TaxonomyLevel2.kt
+++ b/modules/logging-api/src/main/java/uk/gov/logging/api/analytics/parameters/data/TaxonomyLevel2.kt
@@ -7,4 +7,5 @@ enum class TaxonomyLevel2(val value: String) {
     GOVUK("govuk"),
     APP_SYSTEM("app system"),
     ACCOUNT("account"),
+    HOME("home")
 }

--- a/modules/logging-api/src/main/java/uk/gov/logging/api/analytics/parameters/data/TaxonomyLevel2.kt
+++ b/modules/logging-api/src/main/java/uk/gov/logging/api/analytics/parameters/data/TaxonomyLevel2.kt
@@ -7,5 +7,6 @@ enum class TaxonomyLevel2(val value: String) {
     GOVUK("govuk"),
     APP_SYSTEM("app system"),
     ACCOUNT("account"),
-    HOME("home")
+    HOME("home"),
+    SETTINGS("settings"),
 }

--- a/modules/logging-api/src/main/java/uk/gov/logging/api/analytics/parameters/data/TaxonomyLevel3.kt
+++ b/modules/logging-api/src/main/java/uk/gov/logging/api/analytics/parameters/data/TaxonomyLevel3.kt
@@ -17,4 +17,5 @@ enum class TaxonomyLevel3(val value: String) {
     UNLOCK("unlock"),
     BIOMETRICS("biometrics"),
     UNDEFINED("undefined"),
+    ERROR("error"),
 }


### PR DESCRIPTION
- add `HOME` (level 2) parameter with value `home` required for the `HomeScreen` analytics in One Login app
-  add "SETTINGS" (level 3) parameter with value `settings` required for the `SettingsScreen` (`ProfileScreen` at the moment) analytics in One Login app
- add "ERROR" (level 3) parameter with value `error` required for the all error screens analytics in One Login app