### PR TITLE
feat: add 'Onboarding' taxonomy type to TaxonomyLevel2.kt

### DIFF
--- a/modules/logging-api/src/main/java/uk/gov/logging/api/analytics/parameters/data/TaxonomyLevel2.kt
+++ b/modules/logging-api/src/main/java/uk/gov/logging/api/analytics/parameters/data/TaxonomyLevel2.kt
@@ -9,4 +9,5 @@ enum class TaxonomyLevel2(val value: String) {
     ACCOUNT("account"),
     HOME("home"),
     SETTINGS("settings"),
+    ONBOARDING("onboarding")
 }

--- a/modules/logging-api/src/main/java/uk/gov/logging/api/analytics/parameters/data/TaxonomyLevel2.kt
+++ b/modules/logging-api/src/main/java/uk/gov/logging/api/analytics/parameters/data/TaxonomyLevel2.kt
@@ -9,5 +9,5 @@ enum class TaxonomyLevel2(val value: String) {
     ACCOUNT("account"),
     HOME("home"),
     SETTINGS("settings"),
-    ONBOARDING("onboarding")
+    ONBOARDING("onboarding"),
 }


### PR DESCRIPTION
Adding 'onboarding' as a level 2 taxonomy option