### PR TITLE
fix: make all parameters lowercase

### DIFF
--- a/modules/logging-api/src/main/java/uk/gov/logging/api/v3dot1/model/TrackEvent.kt
+++ b/modules/logging-api/src/main/java/uk/gov/logging/api/v3dot1/model/TrackEvent.kt
@@ -19,7 +19,7 @@ sealed class TrackEvent(
         private val text: String,
         private val params: RequiredParameters,
     ) : TrackEvent(EventTypes.NAVIGATION_EVENT, params) {
-        private val _text get() = text.take(HUNDRED_CHAR_LIMIT)
+        private val _text get() = text.take(HUNDRED_CHAR_LIMIT).lowercase()
 
         override fun asMap(): Map<out String, Any?> = mapOf<String, Any?>(
             TEXT to _text,
@@ -31,7 +31,7 @@ sealed class TrackEvent(
         private val text: String,
         private val params: RequiredParameters,
     ) : TrackEvent(EventTypes.NAVIGATION_EVENT, params) {
-        private val _text get() = text.take(HUNDRED_CHAR_LIMIT)
+        private val _text get() = text.take(HUNDRED_CHAR_LIMIT).lowercase()
 
         override fun asMap(): Map<out String, Any?> = mapOf<String, Any?>(
             TEXT to _text,
@@ -45,9 +45,9 @@ sealed class TrackEvent(
         private val text: String,
         private val params: RequiredParameters,
     ) : TrackEvent(EventTypes.NAVIGATION_EVENT, params) {
-        private val _linkDomain get() = domain.take(HUNDRED_CHAR_LIMIT)
-        private val _isExternal get() = isExternal.toString()
-        private val _text get() = text.take(HUNDRED_CHAR_LIMIT)
+        private val _linkDomain get() = domain.take(HUNDRED_CHAR_LIMIT).lowercase()
+        private val _isExternal get() = isExternal.toString().lowercase()
+        private val _text get() = text.take(HUNDRED_CHAR_LIMIT).lowercase()
 
         override fun asMap(): Map<out String, Any?> = mapOf<String, Any?>(
             EXTERNAL to _isExternal,
@@ -62,8 +62,8 @@ sealed class TrackEvent(
         private val response: String,
         private val params: RequiredParameters,
     ) : TrackEvent(EventTypes.FORM_EVENT, params) {
-        private val _text get() = text.take(HUNDRED_CHAR_LIMIT)
-        private val _response get() = response.take(HUNDRED_CHAR_LIMIT)
+        private val _text get() = text.take(HUNDRED_CHAR_LIMIT).lowercase()
+        private val _response get() = response.take(HUNDRED_CHAR_LIMIT).lowercase()
 
         override fun asMap(): Map<out String, Any?> = mapOf<String, Any?>(
             TEXT to _text,
@@ -77,8 +77,8 @@ sealed class TrackEvent(
         private val response: String,
         private val params: RequiredParameters,
     ) : TrackEvent(EventTypes.FORM_EVENT, params) {
-        private val _text get() = text.take(HUNDRED_CHAR_LIMIT)
-        private val _response get() = response.take(HUNDRED_CHAR_LIMIT)
+        private val _text get() = text.take(HUNDRED_CHAR_LIMIT).lowercase()
+        private val _response get() = response.take(HUNDRED_CHAR_LIMIT).lowercase()
 
         override fun asMap(): Map<out String, Any?> = mapOf<String, Any?>(
             TEXT to _text,
@@ -92,8 +92,8 @@ sealed class TrackEvent(
         private val response: String,
         private val params: RequiredParameters,
     ) : TrackEvent(EventTypes.FORM_EVENT, params) {
-        private val _text get() = text.take(HUNDRED_CHAR_LIMIT)
-        private val _response get() = response.take(HUNDRED_CHAR_LIMIT)
+        private val _text get() = text.take(HUNDRED_CHAR_LIMIT).lowercase()
+        private val _response get() = response.take(HUNDRED_CHAR_LIMIT).lowercase()
 
         override fun asMap(): Map<out String, Any?> = mapOf<String, Any?>(
             TEXT to _text,
@@ -106,7 +106,7 @@ sealed class TrackEvent(
         private val text: String,
         private val params: RequiredParameters,
     ) : TrackEvent(EventTypes.POPUP_EVENT, params) {
-        private val _text get() = text.take(HUNDRED_CHAR_LIMIT)
+        private val _text get() = text.take(HUNDRED_CHAR_LIMIT).lowercase()
 
         override fun asMap(): Map<out String, Any?> = mapOf<String, Any?>(
             TEXT to _text,
@@ -118,7 +118,7 @@ sealed class TrackEvent(
         private val text: String,
         private val params: RequiredParameters,
     ) : TrackEvent(EventTypes.POPUP_EVENT, params) {
-        private val _text get() = text.take(HUNDRED_CHAR_LIMIT)
+        private val _text get() = text.take(HUNDRED_CHAR_LIMIT).lowercase()
 
         override fun asMap(): Map<out String, Any?> = mapOf<String, Any?>(
             TEXT to _text,

--- a/modules/logging-api/src/main/java/uk/gov/logging/api/v3dot1/model/ViewEvent.kt
+++ b/modules/logging-api/src/main/java/uk/gov/logging/api/v3dot1/model/ViewEvent.kt
@@ -18,8 +18,8 @@ sealed class ViewEvent(params: RequiredParameters) : AnalyticsEvent {
         private val id: String,
         private val params: RequiredParameters,
     ) : ViewEvent(params) {
-        private val _screenName get() = name.take(HUNDRED_CHAR_LIMIT)
-        private val _screenId get() = id.take(HUNDRED_CHAR_LIMIT)
+        private val _screenName get() = name.take(HUNDRED_CHAR_LIMIT).lowercase()
+        private val _screenId get() = id.take(HUNDRED_CHAR_LIMIT).lowercase()
 
         override fun asMap(): Map<out String, Any?> = mapOf(
             SCREEN_ID to _screenId,
@@ -36,10 +36,10 @@ sealed class ViewEvent(params: RequiredParameters) : AnalyticsEvent {
         private val status: String,
         private val params: RequiredParameters,
     ) : ViewEvent(params) {
-        private val _screenName get() = name.take(HUNDRED_CHAR_LIMIT)
-        private val _screenId get() = id.take(HUNDRED_CHAR_LIMIT)
-        private val _endpoint get() = endpoint.take(HUNDRED_CHAR_LIMIT)
-        private val _reason get() = reason.take(HUNDRED_CHAR_LIMIT)
+        private val _screenName get() = name.take(HUNDRED_CHAR_LIMIT).lowercase()
+        private val _screenId get() = id.take(HUNDRED_CHAR_LIMIT).lowercase()
+        private val _endpoint get() = endpoint.take(HUNDRED_CHAR_LIMIT).lowercase()
+        private val _reason get() = reason.take(HUNDRED_CHAR_LIMIT).lowercase()
         private val _status get() = status.take(HUNDRED_CHAR_LIMIT).lowercase()
         private val _hash get() = (_endpoint + "_" + _status).take(HUNDRED_CHAR_LIMIT).lowercase().md5()
 

--- a/modules/logging-api/src/test/java/uk/gov/logging/api/analytics/parameters/ParametersTestData.kt
+++ b/modules/logging-api/src/test/java/uk/gov/logging/api/analytics/parameters/ParametersTestData.kt
@@ -2,7 +2,7 @@ package uk.gov.logging.api.analytics.parameters
 
 object ParametersTestData {
     const val acceptableEndpoint = "unit test endpoint"
-    const val fortyTwoString = "A forty two character length String to use"
-    const val overOneHundredString = "This is a String that is over one hundred characters in " +
-        "length. This is done for validation and demonstration purposes."
+    const val fortyTwoString = "a forty two character length string to use"
+    const val overOneHundredString = "this is a string that is over one hundred characters in " +
+        "length. this is done for validation and demonstration purposes."
 }

--- a/modules/logging-api/src/test/java/uk/gov/logging/api/v3dot1/model/ButtonTest.kt
+++ b/modules/logging-api/src/test/java/uk/gov/logging/api/v3dot1/model/ButtonTest.kt
@@ -25,7 +25,7 @@ class ButtonTest {
         val actual = event.asMap()[TEXT]
         // Then truncate to 100 characters or less the parameters' values
         assertEquals(
-            expected = ParametersTestData.overOneHundredString.take(HUNDRED_CHAR_LIMIT),
+            expected = ParametersTestData.overOneHundredString.take(HUNDRED_CHAR_LIMIT).lowercase(),
             actual = actual,
         )
     }


### PR DESCRIPTION
Quick change to make all data sent in `v3dot1` analytics events into lowercase. This is inline with the previous Analytics Events