### PR TITLE
feat: DCMAW 14397 Update GA4 logging saved_doc_type (Again)

### DIFF
--- a/modules/logging-api/src/main/java/uk/gov/logging/api/analytics/logging/AnalyticsLoggerConstants.kt
+++ b/modules/logging-api/src/main/java/uk/gov/logging/api/analytics/logging/AnalyticsLoggerConstants.kt
@@ -44,6 +44,7 @@ const val TAXONOMY_LEVEL2 = "taxonomy_level2"
 const val TAXONOMY_LEVEL3 = "taxonomy_level3"
 const val SCREEN_ID = "screen_id"
 const val IS_ERROR = "is_error"
+const val SAVED_DOC_TYPE_UNDEFINED = "undefined"
 
 val LOWER_ALPHANUMERIC_FORTY_LIMIT: Pattern = Pattern.compile("^[a-z\\d]{1,40}$")
 val LOWER_ALPHANUMERIC_HUNDRED_LIMIT: Pattern = Pattern.compile("^[a-z\\d]{1,100}$")

--- a/modules/logging-api/src/main/java/uk/gov/logging/api/analytics/parameters/data/SavedDocType.kt
+++ b/modules/logging-api/src/main/java/uk/gov/logging/api/analytics/parameters/data/SavedDocType.kt
@@ -1,9 +1,0 @@
-package uk.gov.logging.api.analytics.parameters.data
-
-enum class SavedDocType(val value: String) {
-    DBS("dbs"),
-    NINO("nino"),
-    VETERAN_CARD("veteran card"),
-    DRIVING_LICENCE("mdl"),
-    UNDEFINED("undefined"),
-}

--- a/modules/logging-api/src/main/java/uk/gov/logging/api/v3dot1/model/RequiredParameters.kt
+++ b/modules/logging-api/src/main/java/uk/gov/logging/api/v3dot1/model/RequiredParameters.kt
@@ -1,9 +1,11 @@
 package uk.gov.logging.api.v3dot1.model
 
+import uk.gov.logging.api.analytics.logging.HUNDRED_CHAR_LIMIT
 import uk.gov.logging.api.analytics.logging.LANGUAGE
 import uk.gov.logging.api.analytics.logging.ORGANISATION
 import uk.gov.logging.api.analytics.logging.PRIMARY_PUBLISHING_ORGANISATION
 import uk.gov.logging.api.analytics.logging.SAVED_DOC_TYPE
+import uk.gov.logging.api.analytics.logging.SAVED_DOC_TYPE_UNDEFINED
 import uk.gov.logging.api.analytics.logging.TAXONOMY_LEVEL1
 import uk.gov.logging.api.analytics.logging.TAXONOMY_LEVEL2
 import uk.gov.logging.api.analytics.logging.TAXONOMY_LEVEL3
@@ -12,7 +14,6 @@ import uk.gov.logging.api.analytics.parameters.data.Organisation
 import uk.gov.logging.api.analytics.parameters.data.Organisation.OT1056
 import uk.gov.logging.api.analytics.parameters.data.PrimaryPublishingOrganisation
 import uk.gov.logging.api.analytics.parameters.data.PrimaryPublishingOrganisation.GDS_DI
-import uk.gov.logging.api.analytics.parameters.data.SavedDocType
 import uk.gov.logging.api.analytics.parameters.data.TaxonomyLevel1
 import uk.gov.logging.api.analytics.parameters.data.TaxonomyLevel1.ONE_LOGIN
 import uk.gov.logging.api.analytics.parameters.data.TaxonomyLevel2
@@ -24,7 +25,7 @@ import java.util.Locale
 /**
  * Base class for providing values that's required for all events. These are:
  *
- * - [SAVED_DOC_TYPE], with the value of [savedDocType]. Default [UNDEFINED]
+ * - [SAVED_DOC_TYPE], with the value of [String]. Default [UNDEFINED]
  * - [PRIMARY_PUBLISHING_ORGANISATION], with the value of [primaryPublishingOrganisation]. Default[GDS_DI]
  * - [ORGANISATION], with the value of [organisation]. Default [OT1056]
  * - [TAXONOMY_LEVEL1], with the value of [taxonomyLevel1]. Default [ONE_LOGIN]
@@ -35,16 +36,17 @@ import java.util.Locale
  *  - [GA4 Data Schema V3.1](https://govukverify.atlassian.net/wiki/x/qwD24Q)
  */
 open class RequiredParameters(
-    private val savedDocType: SavedDocType = SavedDocType.UNDEFINED,
+    private val savedDocType: String = SAVED_DOC_TYPE_UNDEFINED,
     private val primaryPublishingOrganisation: PrimaryPublishingOrganisation = GDS_DI,
     private val organisation: Organisation = OT1056,
     private val taxonomyLevel1: TaxonomyLevel1 = ONE_LOGIN,
     private val taxonomyLevel2: TaxonomyLevel2,
     private val taxonomyLevel3: TaxonomyLevel3 = UNDEFINED,
 ) : Mapper {
+    private val _savedDocType get() = savedDocType.take(HUNDRED_CHAR_LIMIT)
 
     override fun asMap(): Map<out String, Any?> = mapOf(
-        SAVED_DOC_TYPE to savedDocType.value,
+        SAVED_DOC_TYPE to _savedDocType,
         PRIMARY_PUBLISHING_ORGANISATION to primaryPublishingOrganisation.value,
         ORGANISATION to organisation.value,
         TAXONOMY_LEVEL1 to taxonomyLevel1.value,

--- a/modules/logging-api/src/test/java/uk/gov/logging/api/v3dot1/model/RequiredParametersTest.kt
+++ b/modules/logging-api/src/test/java/uk/gov/logging/api/v3dot1/model/RequiredParametersTest.kt
@@ -1,15 +1,17 @@
 package uk.gov.logging.api.v3dot1.model
 
+import uk.gov.logging.api.analytics.logging.HUNDRED_CHAR_LIMIT
 import uk.gov.logging.api.analytics.logging.LANGUAGE
 import uk.gov.logging.api.analytics.logging.ORGANISATION
 import uk.gov.logging.api.analytics.logging.PRIMARY_PUBLISHING_ORGANISATION
 import uk.gov.logging.api.analytics.logging.SAVED_DOC_TYPE
+import uk.gov.logging.api.analytics.logging.SAVED_DOC_TYPE_UNDEFINED
 import uk.gov.logging.api.analytics.logging.TAXONOMY_LEVEL1
 import uk.gov.logging.api.analytics.logging.TAXONOMY_LEVEL2
 import uk.gov.logging.api.analytics.logging.TAXONOMY_LEVEL3
+import uk.gov.logging.api.analytics.parameters.ParametersTestData
 import uk.gov.logging.api.analytics.parameters.data.Organisation.OT1056
 import uk.gov.logging.api.analytics.parameters.data.PrimaryPublishingOrganisation.GDS_DI
-import uk.gov.logging.api.analytics.parameters.data.SavedDocType
 import uk.gov.logging.api.analytics.parameters.data.TaxonomyLevel1.ONE_LOGIN
 import uk.gov.logging.api.analytics.parameters.data.TaxonomyLevel2
 import uk.gov.logging.api.analytics.parameters.data.TaxonomyLevel3
@@ -20,7 +22,7 @@ import kotlin.test.assertEquals
 class RequiredParametersTest {
 
     private val expectedMap = mapOf(
-        SAVED_DOC_TYPE to SavedDocType.UNDEFINED.value,
+        SAVED_DOC_TYPE to SAVED_DOC_TYPE_UNDEFINED,
         PRIMARY_PUBLISHING_ORGANISATION to GDS_DI.value,
         ORGANISATION to OT1056.value,
         TAXONOMY_LEVEL1 to ONE_LOGIN.value,
@@ -28,6 +30,20 @@ class RequiredParametersTest {
         TAXONOMY_LEVEL3 to TaxonomyLevel3.UNDEFINED.value,
         LANGUAGE to Locale.getDefault().language,
     )
+
+    @Test
+    fun `parameter values are truncated to be 100 characters or less`() {
+        // Given RequiredParameters with values longer than 100 characters
+        val parameters = RequiredParameters(
+            savedDocType = ParametersTestData.overOneHundredString,
+            taxonomyLevel2 = TaxonomyLevel2.DOCUMENT_CHECKING_APP,
+            taxonomyLevel3 = TaxonomyLevel3.UNDEFINED,
+        )
+        val actualDocType = parameters.asMap()[SAVED_DOC_TYPE]
+        // Then truncate to 100 characters or less the parameters' values
+        val expected = ParametersTestData.overOneHundredString.take(HUNDRED_CHAR_LIMIT)
+        assertEquals(expected, actualDocType)
+    }
 
     @Test
     fun `Required Parameters present in the result`() {


### PR DESCRIPTION
# _DCMAW-14397: Update GA4 logging saved_doc_type_

[DCMAW-14397](https://govukverify.atlassian.net/browse/DCMAW-14397)

- Make saved_doc_type dynamic
- Update RequiredParameters to take a string for saved_doc_type Update AnalyticsLoggerConstants to have SAVED_DOC_TYPE_UNDEFINED
- Update RequiredParametersTest to verify truncated string
- Remove SavedDocType enum

## Evidence of the change

- None

## Checklist

### Before creating the pull request

- [x] Commit messages that conform to conventional commit messages.
- [x] Ran the app locally ensuring it builds.
- [x] Tests pass locally.
- [x] Pull request has a clear title with a short description about the feature or update.
- [x] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [x] Complete all Acceptance Criteria within Jira ticket.
- [x] Self-review code.
- [x] Successfully run changes on a testing device.
- [x] Complete automated Testing:
  * [x] Unit Tests.
  * [x] Integration Tests.
  * [x] Instrumentation / Emulator Tests.
- [x] Review [Accessibility considerations].
- [x] Handle PR comments.

### Before merging the pull request

- [x] [Sonar cloud report] passes inspections for your PR.
- [x] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=mobile-android-logging
[Accessibility considerations]: https://developer.android.com/guide/topics/ui/accessibility/testing

[DCMAW-14397]: https://govukverify.atlassian.net/browse/DCMAW-14397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ