### PR TITLE
fix: DCMAW-15145 map screen class to screen name instead of screen id

### DIFF
--- a/modules/logging-api/src/main/java/uk/gov/logging/api/v3dot1/model/ViewEvent.kt
+++ b/modules/logging-api/src/main/java/uk/gov/logging/api/v3dot1/model/ViewEvent.kt
@@ -25,7 +25,7 @@ sealed class ViewEvent(params: RequiredParameters) : AnalyticsEvent {
         override fun asMap(): Map<out String, Any?> = mapOf(
             IS_ERROR to "false",
             SCREEN_ID to _screenId,
-            FirebaseAnalytics.Param.SCREEN_CLASS to _screenId,
+            FirebaseAnalytics.Param.SCREEN_CLASS to _screenName,
             FirebaseAnalytics.Param.SCREEN_NAME to _screenName,
         ) + params.asMap()
     }
@@ -52,7 +52,7 @@ sealed class ViewEvent(params: RequiredParameters) : AnalyticsEvent {
             REASON to _reason,
             STATUS to _status,
             HASH to _hash,
-            FirebaseAnalytics.Param.SCREEN_CLASS to _screenId,
+            FirebaseAnalytics.Param.SCREEN_CLASS to _screenName,
             FirebaseAnalytics.Param.SCREEN_NAME to _screenName,
         ) + params.asMap()
     }

--- a/modules/logging-api/src/test/java/uk/gov/logging/api/v3dot1/model/ScreenTest.kt
+++ b/modules/logging-api/src/test/java/uk/gov/logging/api/v3dot1/model/ScreenTest.kt
@@ -52,7 +52,7 @@ class ScreenTest {
     fun `Verify map output`() {
         val expectedMap: Map<String, Any?> = mapOf(
             SCREEN_ID to exampleId,
-            SCREEN_CLASS to exampleId,
+            SCREEN_CLASS to exampleScreenName.lowercase(),
             SCREEN_NAME to exampleScreenName.lowercase(),
         )
 


### PR DESCRIPTION
# _DCMAW-15145: fix SCREEN_CLASS field_

Changes:
- map to `SCREEN_NAME` instead of `SCREEN_ID`

## Evidence of the change


## Checklist

### Before creating the pull request

- [ ] Commit messages that conform to conventional commit messages.
- [ ] Ran the app locally ensuring it builds.
- [ ] Tests pass locally.
- [ ] Pull request has a clear title with a short description about the feature or update.
- [ ] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] Complete all Acceptance Criteria within Jira ticket.
- [ ] Self-review code.
- [ ] Successfully run changes on a testing device.
- [ ] Complete automated Testing:
  * [ ] Unit Tests.
  * [ ] Integration Tests.
  * [ ] Instrumentation / Emulator Tests.
- [ ] Review [Accessibility considerations].
- [ ] Handle PR comments.

### Before merging the pull request

- [ ] [Sonar cloud report] passes inspections for your PR.
- [ ] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=mobile-android-logging
[Accessibility considerations]: https://developer.android.com/guide/topics/ui/accessibility/testing
