### PR TITLE
fix: Firebase custom keys apply to unrelated non-fatals

### DIFF
--- a/modules/logging-impl/build.gradle.kts
+++ b/modules/logging-impl/build.gradle.kts
@@ -50,6 +50,9 @@ android {
             isIncludeAndroidResources = true
         }
     }
+    testFixtures {
+        enable = true
+    }
 }
 
 dependencies {

--- a/modules/logging-impl/src/main/java/uk/gov/logging/impl/crashlytics/FirebaseCrashlyticsWrapper.kt
+++ b/modules/logging-impl/src/main/java/uk/gov/logging/impl/crashlytics/FirebaseCrashlyticsWrapper.kt
@@ -1,0 +1,12 @@
+package uk.gov.logging.impl.crashlytics
+
+interface FirebaseCrashlyticsWrapper {
+    fun log(message: String)
+
+    fun recordException(throwable: Throwable)
+
+    fun recordException(
+        throwable: Throwable,
+        keys: Map<String, String>,
+    )
+}

--- a/modules/logging-impl/src/main/java/uk/gov/logging/impl/crashlytics/FirebaseCrashlyticsWrapperImpl.kt
+++ b/modules/logging-impl/src/main/java/uk/gov/logging/impl/crashlytics/FirebaseCrashlyticsWrapperImpl.kt
@@ -1,0 +1,30 @@
+package uk.gov.logging.impl.crashlytics
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.google.firebase.crashlytics.recordException
+
+/**
+ * Thin wrapper that delegates to Firebase Crashlytics.
+ *
+ * This class should contain as little logic as possible.
+ */
+class FirebaseCrashlyticsWrapperImpl(
+    private val crashlytics: FirebaseCrashlytics,
+) : FirebaseCrashlyticsWrapper {
+    override fun log(message: String) {
+        crashlytics.log(message)
+    }
+
+    override fun recordException(throwable: Throwable) {
+        crashlytics.recordException(throwable)
+    }
+
+    override fun recordException(
+        throwable: Throwable,
+        keys: Map<String, String>,
+    ) {
+        crashlytics.recordException(throwable) {
+            keys.forEach { (k, v) -> key(k, v) }
+        }
+    }
+}

--- a/modules/logging-impl/src/main/java/uk/gov/logging/impl/v2/CrashlyticsLogger.kt
+++ b/modules/logging-impl/src/main/java/uk/gov/logging/impl/v2/CrashlyticsLogger.kt
@@ -1,9 +1,10 @@
 package uk.gov.logging.impl.v2
 
 import com.google.firebase.crashlytics.FirebaseCrashlytics
-import com.google.firebase.crashlytics.recordException
 import uk.gov.logging.api.v2.CrashLogger
 import uk.gov.logging.api.v2.errorKeys.ErrorKeys
+import uk.gov.logging.impl.crashlytics.FirebaseCrashlyticsWrapper
+import uk.gov.logging.impl.crashlytics.FirebaseCrashlyticsWrapperImpl
 
 @Deprecated(
     message =
@@ -15,16 +16,23 @@ import uk.gov.logging.api.v2.errorKeys.ErrorKeys
         ),
     level = DeprecationLevel.WARNING,
 )
-class CrashlyticsLogger(
-    private val crashlytics: FirebaseCrashlytics,
+class CrashlyticsLogger internal constructor(
+    private val crashlytics: FirebaseCrashlyticsWrapper,
 ) : CrashLogger {
+    constructor(
+        crashlytics: FirebaseCrashlytics,
+    ) : this(
+        crashlytics = FirebaseCrashlyticsWrapperImpl(crashlytics),
+    )
+
     override fun log(
         throwable: Throwable,
         vararg errorKeys: ErrorKeys,
     ) {
-        crashlytics.recordException(throwable) {
-            errorKeys.forEach { key(it.key, it.value.toString()) }
-        }
+        crashlytics.recordException(
+            throwable,
+            errorKeys.associate { it.key to it.value.toString() },
+        )
     }
 
     override fun log(throwable: Throwable) {

--- a/modules/logging-impl/src/main/java/uk/gov/logging/impl/v2/CrashlyticsLogger.kt
+++ b/modules/logging-impl/src/main/java/uk/gov/logging/impl/v2/CrashlyticsLogger.kt
@@ -1,6 +1,7 @@
 package uk.gov.logging.impl.v2
 
 import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.google.firebase.crashlytics.recordException
 import uk.gov.logging.api.v2.CrashLogger
 import uk.gov.logging.api.v2.errorKeys.ErrorKeys
 
@@ -21,11 +22,8 @@ class CrashlyticsLogger(
         throwable: Throwable,
         vararg errorKeys: ErrorKeys,
     ) {
-        crashlytics.recordException(throwable)
-        errorKeys.forEach {
-            it.let {
-                crashlytics.setCustomKey(it.key, it.value.toString())
-            }
+        crashlytics.recordException(throwable) {
+            errorKeys.forEach { key(it.key, it.value.toString()) }
         }
     }
 

--- a/modules/logging-impl/src/main/java/uk/gov/logging/impl/v3/CrashlyticsLogger.kt
+++ b/modules/logging-impl/src/main/java/uk/gov/logging/impl/v3/CrashlyticsLogger.kt
@@ -1,6 +1,7 @@
 package uk.gov.logging.impl.v3
 
 import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.google.firebase.crashlytics.recordException
 import uk.gov.logging.api.v3.LogEntry
 import uk.gov.logging.api.v3.LogLevel
 import uk.gov.logging.api.v3.Logger
@@ -18,10 +19,9 @@ class CrashlyticsLogger(
         crashlytics.log(entry.asLogMessage())
 
         if (entry is LogEntry.Exception) {
-            entry.customKeys.forEach {
-                crashlytics.setCustomKey(it.key, it.value.toString())
+            crashlytics.recordException(entry.throwable) {
+                entry.customKeys.forEach { key(it.key, it.value.toString()) }
             }
-            crashlytics.recordException(entry.throwable)
         }
     }
 }

--- a/modules/logging-impl/src/main/java/uk/gov/logging/impl/v3/CrashlyticsLogger.kt
+++ b/modules/logging-impl/src/main/java/uk/gov/logging/impl/v3/CrashlyticsLogger.kt
@@ -1,15 +1,22 @@
 package uk.gov.logging.impl.v3
 
 import com.google.firebase.crashlytics.FirebaseCrashlytics
-import com.google.firebase.crashlytics.recordException
 import uk.gov.logging.api.v3.LogEntry
 import uk.gov.logging.api.v3.LogLevel
 import uk.gov.logging.api.v3.Logger
 import uk.gov.logging.api.v3.LoggingProperties
+import uk.gov.logging.impl.crashlytics.FirebaseCrashlyticsWrapper
+import uk.gov.logging.impl.crashlytics.FirebaseCrashlyticsWrapperImpl
 
-class CrashlyticsLogger(
-    private val crashlytics: FirebaseCrashlytics,
+class CrashlyticsLogger internal constructor(
+    private val crashlytics: FirebaseCrashlyticsWrapper,
 ) : Logger {
+    constructor(
+        crashlytics: FirebaseCrashlytics,
+    ) : this(
+        crashlytics = FirebaseCrashlyticsWrapperImpl(crashlytics),
+    )
+
     override fun log(
         entry: LogEntry,
         properties: LoggingProperties,
@@ -19,9 +26,10 @@ class CrashlyticsLogger(
         crashlytics.log(entry.asLogMessage())
 
         if (entry is LogEntry.Exception) {
-            crashlytics.recordException(entry.throwable) {
-                entry.customKeys.forEach { key(it.key, it.value.toString()) }
-            }
+            crashlytics.recordException(
+                entry.throwable,
+                entry.customKeys.associate { it.key to it.value.toString() },
+            )
         }
     }
 }

--- a/modules/logging-impl/src/test/java/uk/gov/logging/impl/crashlytics/FirebaseCrashlyticsWrapperImplTest.kt
+++ b/modules/logging-impl/src/test/java/uk/gov/logging/impl/crashlytics/FirebaseCrashlyticsWrapperImplTest.kt
@@ -1,0 +1,39 @@
+package uk.gov.logging.impl.crashlytics
+
+import com.google.firebase.crashlytics.CustomKeysAndValues
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class FirebaseCrashlyticsWrapperImplTest {
+    private val firebaseCrashlytics: FirebaseCrashlytics = mock()
+    private val wrapper = FirebaseCrashlyticsWrapperImpl(firebaseCrashlytics)
+
+    @Test
+    fun `log delegates to firebase crashlytics`() {
+        wrapper.log("message")
+
+        verify(firebaseCrashlytics).log(eq("message"))
+    }
+
+    @Test
+    fun `recordException delegates to firebase crashlytics`() {
+        val throwable = RuntimeException("error")
+
+        wrapper.recordException(throwable)
+
+        verify(firebaseCrashlytics).recordException(eq(throwable))
+    }
+
+    @Test
+    fun `recordException with keys delegates to firebase crashlytics`() {
+        val throwable = RuntimeException("error")
+
+        wrapper.recordException(throwable, mapOf("key" to "value"))
+
+        verify(firebaseCrashlytics).recordException(eq(throwable), any<CustomKeysAndValues>())
+    }
+}

--- a/modules/logging-impl/src/test/java/uk/gov/logging/impl/v2/CrashlyticsLoggerTest.kt
+++ b/modules/logging-impl/src/test/java/uk/gov/logging/impl/v2/CrashlyticsLoggerTest.kt
@@ -1,39 +1,40 @@
 package uk.gov.logging.impl.v2
 
-import com.google.firebase.crashlytics.CustomKeysAndValues
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
-import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
-import uk.gov.logging.api.v2.CrashLogger
 import uk.gov.logging.api.v2.errorKeys.ErrorKeys
+import uk.gov.logging.impl.crashlytics.TestFirebaseCrashlyticsWrapper
+import uk.gov.logging.impl.crashlytics.TestFirebaseCrashlyticsWrapper.RecordedException
 import java.util.stream.Stream
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 class CrashlyticsLoggerTest {
-    private val firebaseCrashlytics: FirebaseCrashlytics = mock()
-
-    private val crashLogger: CrashLogger by lazy {
-        CrashlyticsLogger(firebaseCrashlytics)
-    }
+    private val crashlytics = TestFirebaseCrashlyticsWrapper()
+    private val crashLogger = CrashlyticsLogger(crashlytics)
 
     @Test
     fun `log single string message on firebase crashlytics`() {
         val logMessage = "log message"
+
         crashLogger.log(logMessage)
 
-        verify(firebaseCrashlytics).log(eq(logMessage))
+        assertEquals(listOf(logMessage), crashlytics.loggedMessages)
     }
 
     @Test
     fun `log throwable message on firebase crashlytics`() {
         crashLogger.log(exception)
-        verify(firebaseCrashlytics).recordException(eq(exception))
+
+        assertEquals(
+            listOf(RecordedException(exception, emptyMap())),
+            crashlytics.recordedExceptions,
+        )
     }
 
     @ParameterizedTest(name = "{index}: test key {2} with value {3}")
@@ -46,7 +47,17 @@ class CrashlyticsLoggerTest {
     ) {
         crashLogger.log(throwable, errorKeys)
 
-        verify(firebaseCrashlytics).recordException(eq(throwable), any<CustomKeysAndValues>())
+        assertEquals(
+            listOf(RecordedException(throwable, mapOf(expectedKey to expectedValue))),
+            crashlytics.recordedExceptions,
+        )
+    }
+
+    @Test
+    fun `can be constructed with FirebaseCrashlytics`() {
+        val firebaseCrashlytics: FirebaseCrashlytics = mock()
+
+        assertNotNull(CrashlyticsLogger(firebaseCrashlytics))
     }
 
     companion object {

--- a/modules/logging-impl/src/test/java/uk/gov/logging/impl/v2/CrashlyticsLoggerTest.kt
+++ b/modules/logging-impl/src/test/java/uk/gov/logging/impl/v2/CrashlyticsLoggerTest.kt
@@ -1,11 +1,13 @@
 package uk.gov.logging.impl.v2
 
+import com.google.firebase.crashlytics.CustomKeysAndValues
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -44,7 +46,7 @@ class CrashlyticsLoggerTest {
     ) {
         crashLogger.log(throwable, errorKeys)
 
-        verify(firebaseCrashlytics).setCustomKey(eq(expectedKey), eq(expectedValue))
+        verify(firebaseCrashlytics).recordException(eq(throwable), any<CustomKeysAndValues>())
     }
 
     companion object {

--- a/modules/logging-impl/src/test/java/uk/gov/logging/impl/v3/CrashlyticsLoggerTest.kt
+++ b/modules/logging-impl/src/test/java/uk/gov/logging/impl/v3/CrashlyticsLoggerTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.logging.impl.v3
 
+import com.google.firebase.crashlytics.CustomKeysAndValues
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -8,6 +9,7 @@ import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import uk.gov.logging.api.v3.LogEntry
@@ -53,11 +55,11 @@ class CrashlyticsLoggerTest {
         )
 
         verify(firebaseCrashlytics).log(eq("E : $tag : $message"))
-        verify(firebaseCrashlytics).recordException(eq(throwable))
+        verify(firebaseCrashlytics).recordException(eq(throwable), any<CustomKeysAndValues>())
     }
 
     @Test
-    fun `exception entry sets custom keys`() {
+    fun `exception entry records exception with custom keys`() {
         logger.log(
             LogEntry.Error(
                 tag = tag,
@@ -68,7 +70,7 @@ class CrashlyticsLoggerTest {
             LoggingProperties(allowRemote = true),
         )
 
-        verify(firebaseCrashlytics).setCustomKey(eq(customKey.key), eq(customKey.value))
+        verify(firebaseCrashlytics).recordException(eq(throwable), any<CustomKeysAndValues>())
     }
 
     companion object {

--- a/modules/logging-impl/src/test/java/uk/gov/logging/impl/v3/CrashlyticsLoggerTest.kt
+++ b/modules/logging-impl/src/test/java/uk/gov/logging/impl/v3/CrashlyticsLoggerTest.kt
@@ -1,25 +1,25 @@
 package uk.gov.logging.impl.v3
 
-import com.google.firebase.crashlytics.CustomKeysAndValues
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.verifyNoInteractions
-import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
-import org.mockito.kotlin.verify
+import org.mockito.kotlin.mock
 import uk.gov.logging.api.v3.LogEntry
 import uk.gov.logging.api.v3.LoggingProperties
 import uk.gov.logging.api.v3.customkey.CustomKey
+import uk.gov.logging.impl.crashlytics.TestFirebaseCrashlyticsWrapper
+import uk.gov.logging.impl.crashlytics.TestFirebaseCrashlyticsWrapper.RecordedException
 import java.util.stream.Stream
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class CrashlyticsLoggerTest {
-    private val firebaseCrashlytics: FirebaseCrashlytics = mock()
-    private val logger = CrashlyticsLogger(firebaseCrashlytics)
+    private val crashlytics = TestFirebaseCrashlyticsWrapper()
+    private val logger = CrashlyticsLogger(crashlytics)
     private val tag = "tag"
     private val message = "msg"
     private val throwable = RuntimeException("error")
@@ -29,7 +29,8 @@ class CrashlyticsLoggerTest {
     fun `entries with allowRemote false are not logged`() {
         logger.log(LogEntry.Debug(tag = tag, message = message), LoggingProperties(allowRemote = false))
 
-        verifyNoInteractions(firebaseCrashlytics)
+        assertTrue(crashlytics.loggedMessages.isEmpty())
+        assertTrue(crashlytics.recordedExceptions.isEmpty())
     }
 
     @ParameterizedTest(name = "{0}")
@@ -40,37 +41,42 @@ class CrashlyticsLoggerTest {
     ) {
         logger.log(entry, LoggingProperties(allowRemote = true))
 
-        verify(firebaseCrashlytics).log(eq("$expectedSymbol : $tag : $message"))
+        assertEquals(listOf("$expectedSymbol : $tag : $message"), crashlytics.loggedMessages)
     }
 
     @Test
     fun `exception entry logs message and records exception`() {
         logger.log(
-            LogEntry.Error(
-                tag = tag,
-                message = message,
-                throwable = throwable,
-            ),
+            LogEntry.Error(tag = tag, message = message, throwable = throwable),
             LoggingProperties(allowRemote = true),
         )
 
-        verify(firebaseCrashlytics).log(eq("E : $tag : $message"))
-        verify(firebaseCrashlytics).recordException(eq(throwable), any<CustomKeysAndValues>())
+        assertEquals(listOf("E : $tag : $message"), crashlytics.loggedMessages)
+        assertEquals(
+            listOf(RecordedException(throwable, emptyMap())),
+            crashlytics.recordedExceptions,
+        )
     }
 
     @Test
     fun `exception entry records exception with custom keys`() {
         logger.log(
-            LogEntry.Error(
-                tag = tag,
-                message = message,
-                throwable = throwable,
-                customKeys = listOf(customKey),
-            ),
+            LogEntry.Error(tag = tag, message = message, throwable = throwable, customKeys = listOf(customKey)),
             LoggingProperties(allowRemote = true),
         )
 
-        verify(firebaseCrashlytics).recordException(eq(throwable), any<CustomKeysAndValues>())
+        assertEquals(listOf("E : $tag : $message"), crashlytics.loggedMessages)
+        assertEquals(
+            listOf(RecordedException(throwable, mapOf(customKey.key to customKey.value))),
+            crashlytics.recordedExceptions,
+        )
+    }
+
+    @Test
+    fun `can be constructed with FirebaseCrashlytics`() {
+        val firebaseCrashlytics: FirebaseCrashlytics = mock()
+
+        assertNotNull(CrashlyticsLogger(firebaseCrashlytics))
     }
 
     companion object {

--- a/modules/logging-impl/src/testFixtures/java/uk/gov/logging/impl/crashlytics/TestFirebaseCrashlyticsWrapper.kt
+++ b/modules/logging-impl/src/testFixtures/java/uk/gov/logging/impl/crashlytics/TestFirebaseCrashlyticsWrapper.kt
@@ -1,0 +1,26 @@
+package uk.gov.logging.impl.crashlytics
+
+class TestFirebaseCrashlyticsWrapper : FirebaseCrashlyticsWrapper {
+    val loggedMessages = mutableListOf<String>()
+    val recordedExceptions = mutableListOf<RecordedException>()
+
+    override fun log(message: String) {
+        loggedMessages += message
+    }
+
+    override fun recordException(throwable: Throwable) {
+        recordedExceptions += RecordedException(throwable, emptyMap())
+    }
+
+    override fun recordException(
+        throwable: Throwable,
+        keys: Map<String, String>,
+    ) {
+        recordedExceptions += RecordedException(throwable, keys)
+    }
+
+    data class RecordedException(
+        val throwable: Throwable,
+        val keys: Map<String, String>,
+    )
+}


### PR DESCRIPTION
## Changes

- Ensure Firebase custom keys are attached only to the specific non-fatal exception they are passed with.
- Add `FirebaseCrashlyticsWrapper` and implementations to enable testing.

## Context

#339 and #342 introduced Logger v2 and v3 which support passing custom keys along with non-fatal exceptions.

These keys are sent to Firebase Crashlytics and associated with the exception that is tracked after setting the key. The aim was to help us filter and group exceptions in Firebase Crashlytics.

However, due to the way we set custom keys, every non-fatal exception that we track after setting custom keys will be associated with the given keys.

This behaviour is noted in https://github.com/firebase/firebase-android-sdk/issues/3551 and a new API was added in [Crashlytics v19.4.0](https://firebase.google.com/support/release-notes/android#crashlytics_v19-4-0) to make it easy to attach custom keys to a specific non-fatal.

[DCMAW-20374](https://govukverify.atlassian.net/browse/DCMAW-20374)

## Evidence of the change

[//]: # (Screenshots / uploaded videos go here)

## Checklist

### Before creating the pull request

- [ ] Commit messages that conform to conventional commit messages.
- [ ] Ran the app locally ensuring it builds.
- [ ] Tests pass locally.
- [ ] Pull request has a clear title with a short description about the feature or update.
- [ ] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] Complete all Acceptance Criteria within Jira ticket.
- [x] Self-review code.
- [ ] Successfully run changes on a testing device.
- [ ] Complete automated Testing:
  * [ ] Unit Tests.
  * [ ] Integration Tests.
  * [ ] Instrumentation / Emulator Tests.
- [ ] Review [Accessibility considerations].
- [ ] Handle PR comments.

### Before merging the pull request

- [ ] [Sonar cloud report] passes inspections for your PR.
- [ ] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=mobile-android-logging
[Accessibility considerations]: https://developer.android.com/guide/topics/ui/accessibility/testing


[DCMAW-20374]: https://govukverify.atlassian.net/browse/DCMAW-20374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ