### PR TITLE
fix: Fix group ID of test fixture publication

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,3 +48,8 @@ plugins {
     id("uk.gov.pipelines.sonarqube-root-config")
     alias(libs.plugins.ksp) apply false
 }
+
+subprojects {
+    val mavenGroupId: String by rootProject.extra
+    group = mavenGroupId
+}


### PR DESCRIPTION
## Changes

- Set `Project.group` in all projects

## Context

Fixes an issue where test fixtures can't be resolved.

I also considered improving the default behaviour for all projects upstream in mobile-android-pipelines. But decided against in case it interferes with how projects are customising the Maven Publishing plugin group ID later in the build.

DCMAW-20640

## Evidence of the change

Tested manually by publishing locally.

```sh
./gradlew publishToMavenLocal
```

### Before

```json
// logging-api.module
      "capabilities": [
        {
          "group": "GDS_Android_Logging.modules",
        }
      ]
```

### After
```json
// logging-api.module
      "capabilities": [
        {
          "group": "uk.gov.logging",
        }
      ]
```
## Checklist

### Before creating the pull request

- [ ] Commit messages that conform to conventional commit messages.
- [ ] Ran the app locally ensuring it builds.
- [ ] Tests pass locally.
- [ ] Pull request has a clear title with a short description about the feature or update.
- [ ] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] Complete all Acceptance Criteria within Jira ticket.
- [ ] Self-review code.
- [ ] Successfully run changes on a testing device.
- [ ] Complete automated Testing:
  * [ ] Unit Tests.
  * [ ] Integration Tests.
  * [ ] Instrumentation / Emulator Tests.
- [ ] Review [Accessibility considerations].
- [ ] Handle PR comments.

### Before merging the pull request

- [ ] [Sonar cloud report] passes inspections for your PR.
- [ ] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=mobile-android-logging
[Accessibility considerations]: https://developer.android.com/guide/topics/ui/accessibility/testing
