### PR TITLE
fix: Fix custom key hamcrest matcher

### DIFF
--- a/modules/logging-api/src/test/java/uk/gov/logging/api/v3/MemorisedLoggerTest.kt
+++ b/modules/logging-api/src/test/java/uk/gov/logging/api/v3/MemorisedLoggerTest.kt
@@ -6,6 +6,7 @@ import org.hamcrest.Matchers.contains
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.not
 import org.junit.jupiter.api.Test
+import uk.gov.logging.api.v3.matchers.LogEntryMatchers.hasCustomKeys
 import uk.gov.logging.api.v3.matchers.LogEntryMatchers.hasException
 import uk.gov.logging.api.v3.matchers.LogEntryMatchers.hasMessage
 import uk.gov.logging.api.v3.matchers.LogEntryMatchers.hasTag
@@ -88,6 +89,23 @@ class MemorisedLoggerTest {
         assertThat(
             logger,
             not(contains(hasException(equalTo(RuntimeException("other"))))),
+        )
+    }
+
+    @Test
+    fun `contains matches by custom keys`() {
+        val customKey = LoggingTestData.intCustomKey
+        logger.log(LogEntry.Error(tag = tag, message = message, throwable = throwable, listOf(customKey)))
+
+        assertThat(
+            logger,
+            contains(
+                hasCustomKeys(
+                    contains(
+                        equalTo(customKey),
+                    ),
+                ),
+            ),
         )
     }
 

--- a/modules/logging-api/src/testFixtures/java/uk/gov/logging/api/v3/matchers/HasCustomKeys.kt
+++ b/modules/logging-api/src/testFixtures/java/uk/gov/logging/api/v3/matchers/HasCustomKeys.kt
@@ -7,7 +7,7 @@ import uk.gov.logging.api.v3.LogEntry
 import uk.gov.logging.api.v3.customkey.CustomKey
 
 internal class HasCustomKeys(
-    private val matcher: Matcher<in CustomKey>,
+    private val matcher: Matcher<in Iterable<CustomKey>>,
 ) : TypeSafeMatcher<LogEntry>() {
     override fun describeTo(description: Description?) {
         matcher.describeTo(description)

--- a/modules/logging-api/src/testFixtures/java/uk/gov/logging/api/v3/matchers/LogEntryMatchers.kt
+++ b/modules/logging-api/src/testFixtures/java/uk/gov/logging/api/v3/matchers/LogEntryMatchers.kt
@@ -29,5 +29,5 @@ object LogEntryMatchers {
 
     fun hasException(matcher: Matcher<in Throwable>): Matcher<in LogEntry> = HasThrowable(matcher)
 
-    fun hasCustomKeys(matcher: Matcher<in CustomKey>): Matcher<in LogEntry> = HasCustomKeys(matcher)
+    fun hasCustomKeys(matcher: Matcher<in Iterable<CustomKey>>): Matcher<in LogEntry> = HasCustomKeys(matcher)
 }


### PR DESCRIPTION
## Changes

Fix type of `hasCustomKeys()` hamcrest matcher.

## Context

Previously, the matcher could never match successfully because it compared a single custom keys against a list of custom keys.

DCMAW-18950

## Evidence of the change

New unit test

## Checklist

### Before creating the pull request

- [ ] Commit messages that conform to conventional commit messages.
- [ ] Ran the app locally ensuring it builds.
- [ ] Tests pass locally.
- [ ] Pull request has a clear title with a short description about the feature or update.
- [ ] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] Complete all Acceptance Criteria within Jira ticket.
- [ ] Self-review code.
- [ ] Successfully run changes on a testing device.
- [ ] Complete automated Testing:
  * [ ] Unit Tests.
  * [ ] Integration Tests.
  * [ ] Instrumentation / Emulator Tests.
- [ ] Review [Accessibility considerations].
- [ ] Handle PR comments.

### Before merging the pull request

- [ ] [Sonar cloud report] passes inspections for your PR.
- [ ] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=mobile-android-logging
[Accessibility considerations]: https://developer.android.com/guide/topics/ui/accessibility/testing
